### PR TITLE
Reduce Python dependency to 3.7.

### DIFF
--- a/hyperx/utils/utils.py
+++ b/hyperx/utils/utils.py
@@ -2,6 +2,7 @@
 Utility methods.
 """
 
+from __future__ import annotations
 from contextlib import contextmanager
 import os
 import subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "HyperX scripting for Python"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Python 3.7 was unhappy with `list[Any]` in utils.py, because before 3.9, list was "not subscriptable"

Now using `from __future__ import annotations` (as used in `./hyperx/api/__init__.py`) to remedy.

I have only tested this in a limited fashion. If there are broader implications it isn't necessary to reduce the "requires" but I would still like to add the annotations import to make it easier to do a special build for special users in the future.